### PR TITLE
remove double plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -394,10 +394,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-      </plugin>
-      <plugin>
         <groupId>com.ning.maven.plugins</groupId>
         <artifactId>maven-duplicate-finder-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
there was two times the configuration for the plugin org.owasp and an error was provided for this.