### PR TITLE
Fix potential large memory allocation in DerInputStream

### DIFF
--- a/crypto-conditions/src/main/java/com/ripple/cryptoconditions/der/DerInputStream.java
+++ b/crypto-conditions/src/main/java/com/ripple/cryptoconditions/der/DerInputStream.java
@@ -103,7 +103,7 @@ public class DerInputStream extends FilterInputStream {
     DerObject obj = new DerObject();
     obj.setTag(readTag(innerBytesRead));
     obj.setLength(readLength(innerBytesRead));
-    if (innerBytesRead.get() + obj.getLength() > limit) {
+    if ((long) innerBytesRead.get() + obj.getLength() > limit) {
       throw new DerEncodingException(
           "Object length [" + obj.getLength() + "] is larger than allowed.");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 
     <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
 
-    <jackson.version>[2.9.10.1,3.0.0-SNAPSHOT)</jackson.version>
+    <jackson.version>[2.9.10.1,)</jackson.version>
   </properties>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 
     <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
 
-    <jackson.version>[2.9.10.1,)</jackson.version>
+    <jackson.version>[2.9.10.1,3.0.0-SNAPSHOT)</jackson.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
The object length limit check was adding 2 int values which could result in an overflow exception, allowing very large lengths to bypass the limit enforcement. Now the limit check casts the value to a long before doing addition to avoid integer overflow.