### PR TITLE
Update deploy plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,14 +445,12 @@
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.5.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh-ripple</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
         </configuration>
       </plugin>
       <plugin>
@@ -512,16 +510,5 @@
       </plugin>
     </plugins>
   </reporting>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh-ripple</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh-ripple</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,7 @@
               <exclude>.*\/generated.*sources\/.*</exclude>
             </excludes>
             <source>8</source>
+            <additionalOptions>-Xdoclint:none</additionalOptions>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
Sonatype has a new mechanism to deploy to maven central. This change enables the new system. See https://central.sonatype.org/publish-ea/publish-ea-guide/